### PR TITLE
chore: add missing transitive peerDependencies

### DIFF
--- a/.changeset/thick-lions-wait.md
+++ b/.changeset/thick-lions-wait.md
@@ -2,4 +2,4 @@
 'eslint-plugin-sonar': patch
 ---
 
-Adding missing transitive peer dependencies
+chore: add missing transitive peer dependencies

--- a/.changeset/thick-lions-wait.md
+++ b/.changeset/thick-lions-wait.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-sonar': patch
+---
+
+Adding missing transitive peer dependencies

--- a/eslint-plugin-sonar/package.json
+++ b/eslint-plugin-sonar/package.json
@@ -31,8 +31,8 @@
     "eslint-sonarjs"
   ],
   "peerDependencies": {
-    "@babel/core": ">=7.11.0",
-    "@typescript-eslint/parser": "^5.0.0",
+    "@babel/core": "^7.11.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^7.0.0 || ^8.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },

--- a/eslint-plugin-sonar/package.json
+++ b/eslint-plugin-sonar/package.json
@@ -31,6 +31,8 @@
     "eslint-sonarjs"
   ],
   "peerDependencies": {
+    "@babel/core": ">=7.11.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.0.0 || ^8.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },


### PR DESCRIPTION
`eslint-plugin-sonar` is missing `peerDependencies` on `@babel/core` and `@typescript-eslint/parser`, as transitively requested by `@babel/eslint-parser` and `@typescript-eslint/eslint-plugin` respectively.

While it's not a massive problem, it does make life harder for package managers when trying to optimize package installation, see [Implicit Transitive Peer Dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

yarn currently reports as so:
```
eslint-plugin-sonar@npm:0.12.0 doesn't provide @babel/core, breaking the following requirements:
@babel/eslint-parser@npm:7.22.9 → >=7.11.0

eslint-plugin-sonar@npm:0.12.0 doesn't provide @typescript-eslint/parser, breaking the following requirements:
@typescript-eslint/eslint-plugin@npm:5.62.0 → ^5.0.0
```

Marked as a patch, since consumers will already need to be satisfying these dependencies, so adding the new peer dependencies won't force them to upgrade or install any new packages.